### PR TITLE
Optional, INTERNAL_APPLICATION 1<<11 extension

### DIFF
--- a/flags/user.json
+++ b/flags/user.json
@@ -55,7 +55,7 @@
         "undocumented": false
     },
     "INTERNAL_APPLICATION": {
-        "description": "An internal flag accidentally leaked to the client's private flags. Relates to partner/verification applications but nothing else is known.",
+        "description": "An internal flag accidentally leaked to the client's private flags. Relates to partner/verification applications but nothing else is known. Can be probably called 'Requested partnership and/or verification for guild before'.",
         "shift": 11,
         "undocumented": true
     },


### PR DESCRIPTION
Decide yourself whether to include that, but from experimenting with different account packages and the users flags, the added description makes sense.