### PR TITLE
Add `PROVISIONAL_ACCOUNT` user flag (1 << 23)

### DIFF
--- a/flags/user.json
+++ b/flags/user.json
@@ -114,6 +114,11 @@
         "shift": 22,
         "undocumented": false
     },
+    "PROVISIONAL_ACCOUNT": {
+        "description": "Unknown.",
+        "shift": 23,
+        "undocumented": true
+    },
     "HIGH_GLOBAL_RATE_LIMIT": {
         "description": "Account has a high global ratelimit.",
         "shift": 33,


### PR DESCRIPTION
Source: client flags

![image](https://github.com/lewisakura/discord-flags/assets/9750071/e90e71ac-479e-4a22-afe1-2ea760d04ba1)

Added in [build 303162 (4c32d5344c3c90c9eb8978b8af15e1484f57964a)](https://github.com/Discord-Datamining/Discord-Datamining/commit/24304958a96e396834d75c5ff59ca431120f92cc)

We don't know what it does at the moment. It might be related to slayer integration (whatever that is).