### PR TITLE
Add `PREMIUM_ELIGIBLE_FOR_UNIQUE_USERNAME` and 2 real flag names

### DIFF
--- a/flags/application.json
+++ b/flags/application.json
@@ -102,6 +102,11 @@
         "shift": 20,
         "undocumented": true
     },
+    "APPLICATION_COMMAND_MIGRATED": {
+        "description": "Indicates if an app had it's slash commands migrated before (unknown)",
+        "shift": 21,
+        "undocumented": true
+    },
     "APPLICATION_COMMAND_BADGE": {
         "description": "Indicates if an app has registered global application commands.",
         "shift": 23,
@@ -111,22 +116,22 @@
         "description": "Indicates if an app is considered active. This means that it has had any global command executed in the past 30 days.",
         "shift": 24,
         "undocumented": false
-    },    
+    },
     "IFRAME_MODAL": {
         "description": "Allows the application to use IFrame modals.",
         "shift": 26,
         "undocumented": true
-    },    
+    },
     "SOCIAL_LAYER_INTEGRATION": {
         "description": "Indicates if an app can use the social layer integration.",
         "shift": 27,
         "undocumented": true
-    },    
+    },
     "PROMOTED": {
         "description": "Indicates if an app  is promoted by Discord in the application directory.",
         "shift": 29,
         "undocumented": true
-    },    
+    },
     "PARTNER": {
         "description": "Indicates if an app  is a Discord partner.",
         "shift": 30,

--- a/flags/user.json
+++ b/flags/user.json
@@ -174,6 +174,11 @@
         "shift": 44,
         "undocumented": true
     },
+    "PREMIUM_ELIGIBLE_FOR_UNIQUE_USERNAME": {
+        "description": "User is eligible for early access to pomelo migration.",
+        "shift": 47,
+        "undocumented": true
+    },
     "COLLABORATOR": {
         "description": "User is a collaborator and has staff permissions.",
         "shift": 50,

--- a/flags/user.json
+++ b/flags/user.json
@@ -164,8 +164,8 @@
         "shift": 41,
         "undocumented": true
     },
-    "VERIFIED_EMAIL": {
-        "description": "User has a verified email.",
+    "HAS_SESSION_STARTED": {
+        "description": "User has started at least one Gateway session and is now eligible to send messages.",
         "shift": 43,
         "undocumented": true
     },

--- a/flags/user.json
+++ b/flags/user.json
@@ -54,8 +54,8 @@
         "shift": 10,
         "undocumented": false
     },
-    "INTERNAL_APPLICATION": {
-        "description": "An internal flag accidentally leaked to the client's private flags. Relates to partner/verification applications but nothing else is known.",
+    "HUBSPOT_CONTACT": {
+        "description": "User is registered on Discord's Hubspot customer platform, used for official Discord programs (e.g. partner)",
         "shift": 11,
         "undocumented": true
     },

--- a/flags/user.json
+++ b/flags/user.json
@@ -55,7 +55,7 @@
         "undocumented": false
     },
     "HUBSPOT_CONTACT": {
-        "description": "User is registered on Discord's Hubspot customer platform, used for official Discord programs (e.g. partner)",
+        "description": "User is registered on Discord's Hubspot customer platform, used for official Discord programs (e.g. partner).",
         "shift": 11,
         "undocumented": true
     },


### PR DESCRIPTION
Discord recently started including flags as an array rather than a bitshifted number in data packages:
```diff
- "flags": 27828224
+ "flags": ["GATEWAY_PRESENCE_LIMITED", "GATEWAY_GUILD_MEMBERS_LIMITED", "GATEWAY_MESSAGE_CONTENT_LIMITED", "APPLICATION_COMMAND_MIGRATED", "APPLICATION_COMMAND_BADGE", "ACTIVE"]
```

This revealed that 1 << 21 is APPLICATION_COMMAND_MIGRATED, 1 << 11 is HUBSPOT_CONTACT and 1 << 47 is PREMIUM_ELIGIBLE_FOR_UNIQUE_USERNAME.