### PR TITLE
fix naming of 1<11

### DIFF
--- a/flags/user.json
+++ b/flags/user.json
@@ -54,7 +54,7 @@
         "shift": 10,
         "undocumented": false
     },
-    "HUBSPOT_CONTACT": {
+    "IS_HUBSPOT_CONTACT": {
         "description": "User is registered on Discord's Hubspot customer platform, used for official Discord programs (e.g. partner).",
         "shift": 11,
         "undocumented": true


### PR DESCRIPTION
the discord package reveals the actual name is `IS_HUBSPOT_CONTACT`